### PR TITLE
Fix field name and association

### DIFF
--- a/src/SimpleThings/EntityAudit/AuditReader.php
+++ b/src/SimpleThings/EntityAudit/AuditReader.php
@@ -172,7 +172,7 @@ class AuditReader
                         // Foreign key is NULL
                         $class->reflFields[$field]->setValue($entity, null);
                     } else {
-                        $associatedEntity = $this->em->getReference($targetClass->name, $associatedId);
+                        $associatedEntity = $this->getEntityPersister($targetClass->name)->load($associatedId, $entity, $assoc);
                         $class->reflFields[$field]->setValue($entity, $associatedEntity);
                     }
                 } else {

--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -188,7 +188,7 @@ class LogRevisionsListener implements EventSubscriber
             }
 
             foreach ($class->fieldNames AS $field) {
-                if (array_key_exists($field, $fields)) {
+                if (array_key_exists($class->fieldMappings[$field]['columnName'], $fields)) {
                     continue;
                 }
                 $type = Type::getType($class->fieldMappings[$field]['type']);
@@ -241,7 +241,7 @@ class LogRevisionsListener implements EventSubscriber
         }
 
         foreach ($class->fieldNames AS $field) {
-            if (array_key_exists($field, $fields)) {
+            if (array_key_exists($class->fieldMappings[$field]['columnName'], $fields)) {
                 continue;
             }
             $params[] = $entityData[$field];


### PR DESCRIPTION
Hello,
With the latest version, I found 2 bugs:
- An error of check field name association. The process retrieve the field name of join-column, and adding fields of entity, but the field name of join-column is a column name.
- And an error during hydration, when the association has a join-column without identities.
