### PR TITLE
require DBAL 2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "keywords": ["Persistence", "Database", "Audit"],
     "description": "Audit for Doctrine Entities",
     "require": {
+        "doctrine/dbal": "~2.5",
         "doctrine/orm": "~2.2"
     },
     "require-dev": {


### PR DESCRIPTION
#119 (commit 912303e7) uses `AbstractPlatform::getIdentitySequenceName`,
which is a new method introduced in DBAL 2.5 (see doctrine/dbal@6b4ba50f).