### PR TITLE
Generate database schema when class is extends with abstract class

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/CreateSchemaListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/CreateSchemaListener.php
@@ -60,7 +60,7 @@ class CreateSchemaListener implements EventSubscriber
     {
         $cm = $eventArgs->getClassMetadata();
 
-        if (!$this->metadataFactory->isAudited($cm->name)) {
+        if (!$this->metadataFactory->isClassAudited($cm)) {
             $audited = false;
             if ($cm->isInheritanceTypeJoined() && $cm->rootEntityName == $cm->name) {
                 foreach ($cm->subClasses as $subClass) {

--- a/src/SimpleThings/EntityAudit/Metadata/MetadataFactory.php
+++ b/src/SimpleThings/EntityAudit/Metadata/MetadataFactory.php
@@ -32,11 +32,27 @@ class MetadataFactory
         $this->auditedEntities = array_flip($auditedEntities);
     }
 
-    public function isAudited($entity)
+    public function isAudited($entityName)
     {
-        return isset($this->auditedEntities[$entity]);
+        return isset($this->auditedEntities[$entityName]);
     }
-    
+
+    public function isClassAudited($entityClass)
+    {
+        if ($this->isAudited($entityClass->name)) {
+            return true;
+        }
+        if ($subClasses = $entityClass->subClasses) {
+            foreach ($subClasses as $oneEntityclass) {
+                if ($this->isAudited($oneEntityclass)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     public function getAllClassNames()
     {
         return array_flip($this->auditedEntities);


### PR DESCRIPTION
Currently when class is extended with abstract class the database schema is not generated with doctrine:schema:update. This commit fix that.
