### PR TITLE
2.2 deprecation fixes

### DIFF
--- a/src/SimpleThings/EntityAudit/Resources/config/routing.yml
+++ b/src/SimpleThings/EntityAudit/Resources/config/routing.yml
@@ -1,5 +1,5 @@
 simple_things_entity_audit_home:
-    pattern: /{page}
+    path: /{page}
     defaults:
         _controller: SimpleThingsEntityAuditBundle:Audit:index
         page: 1
@@ -7,21 +7,21 @@ simple_things_entity_audit_home:
         page: \d+
 
 simple_things_entity_audit_viewrevision:
-    pattern: /viewrev/{rev}
+    path: /viewrev/{rev}
     defaults:
         _controller: SimpleThingsEntityAuditBundle:Audit:viewRevision
     requirements:
         rev: \d+
 
 simple_things_entity_audit_viewentity_detail:
-    pattern: /viewent/{className}/{id}/{rev}
+    path: /viewent/{className}/{id}/{rev}
     defaults:
         _controller: SimpleThingsEntityAuditBundle:Audit:viewDetail
     requirements:
         rev: \d+
 
 simple_things_entity_audit_viewentity:
-    pattern: /viewent/{className}/{id}
+    path: /viewent/{className}/{id}
     defaults:
         _controller: SimpleThingsEntityAuditBundle:Audit:viewEntity
 


### PR DESCRIPTION
The `pattern` option is deprecated since 2.2, and need to be replaced with `path`.