### PR TITLE
Fixes to work with schema names post doctrine orm 2.5

### DIFF
--- a/src/SimpleThings/EntityAudit/AuditConfiguration.php
+++ b/src/SimpleThings/EntityAudit/AuditConfiguration.php
@@ -35,6 +35,17 @@ class AuditConfiguration
     private $currentUsername = '';
     private $revisionIdFieldType = 'integer';
 
+    public function getTableName($metadata)
+    {
+        $tableName = $metadata->getTableName();
+
+        if ($metadata->getSchemaName()) {
+            $tableName = $metadata->getSchemaName() . '.' . $tableName;
+        }
+
+        return $this->getTablePrefix() . $tableName . $this->getTableSuffix();
+    }
+
     public function getTablePrefix()
     {
         return $this->prefix;

--- a/src/SimpleThings/EntityAudit/AuditConfiguration.php
+++ b/src/SimpleThings/EntityAudit/AuditConfiguration.php
@@ -39,7 +39,8 @@ class AuditConfiguration
     {
         $tableName = $metadata->getTableName();
 
-        if ($metadata->getSchemaName()) {
+        //## Fix for doctrine/orm >= 2.5
+        if (method_exists($metadata, 'getSchemaName') && $metadata->getSchemaName()) {
             $tableName = $metadata->getSchemaName() . '.' . $tableName;
         }
 

--- a/src/SimpleThings/EntityAudit/AuditReader.php
+++ b/src/SimpleThings/EntityAudit/AuditReader.php
@@ -208,8 +208,7 @@ class AuditReader
         }
 
         $class = $this->em->getClassMetadata($className);
-
-        $tableName = $this->config->getTablePrefix() . $class->table['name'] . $this->config->getTableSuffix();
+        $tableName = $this->config->getTableName($class);
 
         if (!is_array($id)) {
             $id = array($class->identifier[0] => $id);
@@ -262,7 +261,7 @@ class AuditReader
         if ($class->isInheritanceTypeJoined()
             && $class->name != $class->rootEntityName) {
             $rootClass = $this->em->getClassMetadata($class->rootEntityName);
-            $rootTableName = $this->config->getTablePrefix() . $rootClass->table['name'] . $this->config->getTableSuffix();
+            $rootTableName = $this->config->getTableName($rootClass);
             $joinSql = "INNER JOIN {$rootTableName} re ON";
             $joinSql .= " re.rev = e.rev";
             foreach ($class->getIdentifierColumnNames() as $name) {
@@ -530,7 +529,7 @@ class AuditReader
                 continue;
             }
 
-            $tableName = $this->config->getTablePrefix() . $class->table['name'] . $this->config->getTableSuffix();
+            $tableName = $this->config->getTableName($class);
             $params = array();
 
             $whereSQL   = "e." . $this->config->getRevisionFieldName() ." = ?";
@@ -565,7 +564,7 @@ class AuditReader
             } elseif ($class->isInheritanceTypeJoined() && $class->rootEntityName != $class->name) {
                 $columnList .= ', re.' . $class->discriminatorColumn['name'];
                 $rootClass = $this->em->getClassMetadata($class->rootEntityName);
-                $rootTableName = $this->config->getTablePrefix() . $rootClass->table['name'] . $this->config->getTableSuffix();
+                $rootTableName = $this->config->getTableName($rootClass);
                 $joinSql = "INNER JOIN {$rootTableName} re ON";
                 $joinSql .= " re.rev = e.rev";
                 foreach ($class->getIdentifierColumnNames() as $name) {
@@ -629,7 +628,7 @@ class AuditReader
         }
 
         $class = $this->em->getClassMetadata($className);
-        $tableName = $this->config->getTablePrefix() . $class->table['name'] . $this->config->getTableSuffix();
+        $tableName = $this->config->getTableName($class);
 
         if (!is_array($id)) {
             $id = array($class->identifier[0] => $id);
@@ -681,7 +680,7 @@ class AuditReader
         }
 
         $class = $this->em->getClassMetadata($className);
-        $tableName = $this->config->getTablePrefix() . $class->table['name'] . $this->config->getTableSuffix();
+        $tableName = $this->config->getTableName($class);
 
         if (!is_array($id)) {
             $id = array($class->identifier[0] => $id);
@@ -764,7 +763,7 @@ class AuditReader
         }
 
         $class = $this->em->getClassMetadata($className);
-        $tableName = $this->config->getTablePrefix() . $class->table['name'] . $this->config->getTableSuffix();
+        $tableName = $this->config->getTableName($class);
 
         if (!is_array($id)) {
             $id = array($class->identifier[0] => $id);

--- a/src/SimpleThings/EntityAudit/Collection/AuditedCollection.php
+++ b/src/SimpleThings/EntityAudit/Collection/AuditedCollection.php
@@ -451,7 +451,7 @@ class AuditedCollection implements Collection
             if (isset($this->associationDefinition['indexBy'])) {
                 $sql .= ', '.$this->associationDefinition['indexBy'].' ';
             }
-            $sql .= 'FROM '.$this->configuration->getTablePrefix().$this->metadata->table['name'].$this->configuration->getTableSuffix().' t ';
+            $sql .= 'FROM '.$this->configuration->getTableName($this->metadata).' t ';
             $sql .= 'WHERE '.$this->configuration->getRevisionFieldName().' <= '.$this->revision.' ';
 
             foreach ($this->foreignKeys as $column => $value) {
@@ -460,7 +460,7 @@ class AuditedCollection implements Collection
             }
 
             //we check for revisions greater than current belonging to other entities
-            $sql .= 'AND NOT EXISTS (SELECT * FROM '.$this->configuration->getTablePrefix().$this->metadata->table['name'].$this->configuration->getTableSuffix().' st WHERE';
+            $sql .= 'AND NOT EXISTS (SELECT * FROM '.$this->configuration->getTableName($this->metadata).' st WHERE';
 
             //ids
             foreach ($this->metadata->getIdentifierColumnNames() as $name) {
@@ -488,7 +488,7 @@ class AuditedCollection implements Collection
             //end of check for for belonging to other entities
 
             //check for deleted revisions older than requested
-            $sql .= 'AND NOT EXISTS (SELECT * FROM '.$this->configuration->getTablePrefix().$this->metadata->table['name'].$this->configuration->getTableSuffix().' sd WHERE';
+            $sql .= 'AND NOT EXISTS (SELECT * FROM '.$this->configuration->getTableName($this->metadata).' sd WHERE';
 
             //ids
             foreach ($this->metadata->getIdentifierColumnNames() as $name) {

--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -131,7 +131,7 @@ class LogRevisionsListener implements EventSubscriber
             }
 
             foreach ($updateData[$meta->table['name']] as $field => $value) {
-                $sql = 'UPDATE '.$this->config->getTablePrefix() . $meta->table['name'] . $this->config->getTableSuffix().' '.
+                $sql = 'UPDATE '.$this->config->getTableName($meta).' '.
                     'SET '.$field.' = ? '.
                     'WHERE '.$this->config->getRevisionFieldName().' = ? ';
 
@@ -302,7 +302,7 @@ class LogRevisionsListener implements EventSubscriber
     {
         if (!isset($this->insertRevisionSQL[$class->name])) {
             $placeholders = array('?', '?');
-            $tableName    = $this->config->getTablePrefix() . $class->table['name'] . $this->config->getTableSuffix();
+            $tableName    = $this->config->getTableName($class);
 
             $sql = "INSERT INTO " . $tableName . " (" .
                     $this->config->getRevisionFieldName() . ", " . $this->config->getRevisionTypeFieldName();


### PR DESCRIPTION
Starting in doctrine/orm 2.5 the schema name is stored in a separate field in the metadata. This change centralizes the process of getting the audit table name from metadata, and adds in a check to prefix it with a schema name if present.

See #133 

I am not very familiar with git, or this bundle, so hopefully I have gotten all of my ducks in a row.

Thanks!