### PR TITLE
Critical bug fix for Entity visualization in v0.7

### DIFF
--- a/src/SimpleThings/EntityAudit/AuditReader.php
+++ b/src/SimpleThings/EntityAudit/AuditReader.php
@@ -122,6 +122,14 @@ class AuditReader
         $query = "SELECT " . $columnList . " FROM " . $tableName . " e WHERE " . $whereSQL . " ORDER BY e.rev DESC";
         $row = $this->em->getConnection()->fetchAssoc($query, $values);
 
+        // $row has keys with lowercase letters. Converting it to correct capitalization...
+        $newRow = array();
+        foreach ($columnMap as $key => $columnKey) {
+            $newRow[$key] = $row[strtolower($key)];
+        }
+        // Assign to $row the correctly-capitalized keys
+        $row = $newRow;
+
         if (!$row) {
             throw AuditException::noRevisionFound($class->name, $id, $revision);
         }


### PR DESCRIPTION
In v0.7, there is a capitalization issue with `fetchAssoc` on line 123 of `AuditReader` which causes incorrect visualization of entitiy fields. All the data keys are converted to lowercase, and so can't be fetched properly. This pull request fixes this critical bug.