### PR TITLE
[ADD] PHP-CS-Fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 vendor
 tests/SimpleThings/Tests/EntityAudit/cache
 tests/SimpleThings/Tests/EntityAudit/Proxies
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,44 @@
+<?php
+
+$header = <<<EOF
+
+(c) 2011 SimpleThings GmbH
+
+@package SimpleThings\EntityAudit
+@author Benjamin Eberlei <eberlei@simplethings.de>
+@link http://www.simplethings.de
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+EOF;
+
+Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in(array(__DIR__))
+;
+
+return Symfony\CS\Config\Config::create()
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->fixers(array(
+        'header_comment',
+        'newline_after_open_tag',
+        'ordered_use',
+        'long_array_syntax',
+        'php_unit_construct',
+    ))
+    ->setUsingCache(true)
+    ->finder($finder)
+;

--- a/README.md
+++ b/README.md
@@ -257,3 +257,9 @@ This provides you with a few different routes:
 * Proper metadata mapping is necessary, allow to disable versioning for fields and associations.
 * It does NOT work with Joined-Table-Inheritance (Single Table Inheritance should work, but not tested)
 * Many-To-Many associations are NOT versioned
+
+## Contributing
+
+Please before commiting, run this command `./vendor/bin/php-cs-fixer fix --verbose` to normalize the coding style.
+
+If you already have the fixer locally you can run `php-cs-fixer fix .`.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "phpunit/phpunit": "^4.8",
         "symfony/framework-bundle": "~2.7|~3.0",
-        "symfony/var-dumper": "^2.7"
+        "symfony/var-dumper": "^2.7",
+        "fabpot/php-cs-fixer": "^1.11"
     },
     "conflict": {
         "gedmo/doctrine-extensions": "<2.3.1",


### PR DESCRIPTION
### Proposition

In order to fix easily code style convention, many bundles now use [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer).

The `.php_cs` file allow configuration on your needs, actually i've include the same as [Sonata Project](https://github.com/sonata-project/SonataAdminBundle/blob/master/.php_cs).

The use is really simple, when you're developing, type `make cs` or `make cs_dry_run`, thanks to `Makefile`, he will correct all the files with defined rules.

The actual configuration manage, too automatically, headers files of the bundle.

If this solution concurs for you, you're free to modify after merge the configuration.

Cheers :beers: 