### PR TITLE
Change LogRevisionsListener methods to protected

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -41,47 +41,47 @@ class LogRevisionsListener implements EventSubscriber
     /**
      * @var \SimpleThings\EntityAudit\AuditConfiguration
      */
-    private $config;
+    protected $config;
 
     /**
      * @var \SimpleThings\EntityAudit\Metadata\MetadataFactory
      */
-    private $metadataFactory;
+    protected $metadataFactory;
 
     /**
      * @var \Doctrine\DBAL\Connection
      */
-    private $conn;
+    protected $conn;
 
     /**
      * @var \Doctrine\DBAL\Platforms\AbstractPlatform
      */
-    private $platform;
+    protected $platform;
 
     /**
      * @var \Doctrine\ORM\EntityManager
      */
-    private $em;
+    protected $em;
 
     /**
      * @var array
      */
-    private $insertRevisionSQL = array();
+    protected $insertRevisionSQL = array();
 
     /**
      * @var \Doctrine\ORM\UnitOfWork
      */
-    private $uow;
+    protected $uow;
 
     /**
      * @var int
      */
-    private $revisionId;
+    protected $revisionId;
 
     /**
      * @var array
      */
-    private $extraUpdates = array();
+    protected $extraUpdates = array();
 
     public function __construct(AuditManager $auditManager)
     {
@@ -257,7 +257,7 @@ class LogRevisionsListener implements EventSubscriber
      *
      * @return array
      */
-    private function getOriginalEntityData($entity)
+    protected function getOriginalEntityData($entity)
     {
         $class = $this->em->getClassMetadata(get_class($entity));
         $data = $this->uow->getOriginalEntityData($entity);
@@ -269,7 +269,7 @@ class LogRevisionsListener implements EventSubscriber
         return $data;
     }
 
-    private function getRevisionId()
+    protected function getRevisionId()
     {
         if ($this->revisionId === null) {
             $this->conn->insert(
@@ -300,7 +300,7 @@ class LogRevisionsListener implements EventSubscriber
      * @return string
      * @throws \Doctrine\DBAL\DBALException
      */
-    private function getInsertRevisionSQL($class)
+    protected function getInsertRevisionSQL($class)
     {
         if (! isset($this->insertRevisionSQL[$class->name])) {
             $placeholders = array('?', '?');
@@ -363,7 +363,7 @@ class LogRevisionsListener implements EventSubscriber
      * @param array         $entityData
      * @param string        $revType
      */
-    private function saveRevisionEntityData($class, $entityData, $revType)
+    protected function saveRevisionEntityData($class, $entityData, $revType)
     {
         $params = array($this->getRevisionId(), $revType);
         $types = array(\PDO::PARAM_INT, \PDO::PARAM_STR);
@@ -442,7 +442,7 @@ class LogRevisionsListener implements EventSubscriber
      *
      * @return string
      */
-    private function getHash($entity)
+    protected function getHash($entity)
     {
         return implode(
             ' ',
@@ -472,7 +472,7 @@ class LogRevisionsListener implements EventSubscriber
      *
      * @return array
      */
-    private function prepareUpdateData($persister, $entity)
+    protected function prepareUpdateData($persister, $entity)
     {
         $uow = $this->em->getUnitOfWork();
         $classMetadata = $persister->getClassMetadata();


### PR DESCRIPTION
Changed all private methods in `LogRevisionsListener` to protected in order to be able to extend the listener without having to override everything.