### PR TITLE
Allow usage on php7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
   
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "description": "Audit for Doctrine Entities",
     "require": {
-        "php": "^5.3.9",
+        "php": ">=5.3.9",
         "doctrine/dbal": "~2.5",
         "doctrine/orm": "~2.4"
     },


### PR DESCRIPTION
Updated the composer php requirements to allow the usage on any php version greater than or equal to `5.3.9`.