### PR TITLE
Adds support for inherited associations on single-table-inheritance sub-classes

### DIFF
--- a/src/SimpleThings/EntityAudit/AuditReader.php
+++ b/src/SimpleThings/EntityAudit/AuditReader.php
@@ -292,7 +292,7 @@ class AuditReader
 
                 // Support for single table inheritance sub-classes
                 $allDiscrValues = array_flip($class->discriminatorMap);
-                $queriedDiscrValues = [$this->em->getConnection()->quote($class->discriminatorValue)];
+                $queriedDiscrValues = array($this->em->getConnection()->quote($class->discriminatorValue));
                 foreach ($class->subClasses as $subclassName) {
                     $queriedDiscrValues[] = $this->em->getConnection()->quote($allDiscrValues[$subclassName]);
                 }

--- a/src/SimpleThings/EntityAudit/AuditReader.php
+++ b/src/SimpleThings/EntityAudit/AuditReader.php
@@ -290,8 +290,14 @@ class AuditReader
             if ($class->isInheritanceTypeSingleTable()
                 && $class->discriminatorValue !== null) {
 
-                $whereSQL .= " AND " . $class->discriminatorColumn['name'] . " = ?";
-                $values[] = $class->discriminatorValue;
+                // Support for single table inheritance sub-classes
+                $allDiscrValues = array_flip($class->discriminatorMap);
+                $queriedDiscrValues = [$this->em->getConnection()->quote($class->discriminatorValue)];
+                foreach ($class->subClasses as $subclassName) {
+                    $queriedDiscrValues[] = $this->em->getConnection()->quote($allDiscrValues[$subclassName]);
+                }
+
+                $whereSQL .= " AND " . $class->discriminatorColumn['name'] . " IN " . '(' . implode(', ', $queriedDiscrValues) . ')';
             }
         }
 

--- a/tests/SimpleThings/Tests/EntityAudit/BaseTest.php
+++ b/tests/SimpleThings/Tests/EntityAudit/BaseTest.php
@@ -54,6 +54,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
     {
         $reader = new AnnotationReader();
         $driver = new AnnotationDriver($reader);
+        $driver->addPaths([__DIR__ . '/Fixtures']);
         $config = new Configuration();
         $config->setMetadataCacheImpl(new ArrayCache());
         $config->setQueryCacheImpl(new ArrayCache());

--- a/tests/SimpleThings/Tests/EntityAudit/BaseTest.php
+++ b/tests/SimpleThings/Tests/EntityAudit/BaseTest.php
@@ -54,7 +54,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
     {
         $reader = new AnnotationReader();
         $driver = new AnnotationDriver($reader);
-        $driver->addPaths([__DIR__ . '/Fixtures']);
+        $driver->addPaths(array(__DIR__ . '/Fixtures'));
         $config = new Configuration();
         $config->setMetadataCacheImpl(new ArrayCache());
         $config->setQueryCacheImpl(new ArrayCache());

--- a/tests/SimpleThings/Tests/EntityAudit/Fixtures/Issue/Issue156Client.php
+++ b/tests/SimpleThings/Tests/EntityAudit/Fixtures/Issue/Issue156Client.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: david
+ * Date: 23/02/2016
+ * Time: 15:57
+ */
+
+namespace SimpleThings\EntityAudit\Tests\Fixtures\Issue;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Class Issue156Client
+ * @package SimpleThings\EntityAudit\Tests\Fixtures\Issue
+ * @ORM\Entity()
+ */
+class Issue156Client extends Issue156Contact
+{
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    protected $clientSpecificField;
+
+    /**
+     * @param string $clientSpecificField
+     * @return $this
+     */
+    public function setClientSpecificField($clientSpecificField)
+    {
+        $this->clientSpecificField = $clientSpecificField;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientSpecificField()
+    {
+        return $this->clientSpecificField;
+    }
+}

--- a/tests/SimpleThings/Tests/EntityAudit/Fixtures/Issue/Issue156Contact.php
+++ b/tests/SimpleThings/Tests/EntityAudit/Fixtures/Issue/Issue156Contact.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: david
+ * Date: 23/02/2016
+ * Time: 15:57
+ */
+
+namespace SimpleThings\EntityAudit\Tests\Fixtures\Issue;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Class Issue156Contact
+ * @package SimpleThings\EntityAudit\Tests\Fixtures\Issue
+ * @ORM\Entity()
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorColumn(name="discriminator", type="string")
+ */
+class Issue156Contact
+{
+    /** @var int @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue(strategy="AUTO") */
+    protected $id;
+
+    /**
+     * @var ArrayCollection|Issue156ContactTelephoneNumber[]
+     * ORM\OneToMany(targetEntity="Issue156ContactTelephoneNumber", mappedBy="contact")
+     */
+    protected $telephoneNumbers;
+
+    public function __construct()
+    {
+        $this->telephoneNumbers = new ArrayCollection();
+    }
+
+    /**
+     * @param int $id
+     * @return $this
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param Issue156ContactTelephoneNumber $telephoneNumber
+     * @return $this
+     */
+    public function addTelephoneNumber(Issue156ContactTelephoneNumber $telephoneNumber)
+    {
+        if (!$this->telephoneNumbers->contains($telephoneNumber)) {
+            $telephoneNumber->setContact($this);
+            $this->telephoneNumbers[] = $telephoneNumber;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param Issue156ContactTelephoneNumber $telephoneNumber
+     * @return $this
+     */
+    public function removeTelephoneNumber(Issue156ContactTelephoneNumber $telephoneNumber)
+    {
+        $this->telephoneNumbers->removeElement($telephoneNumber);
+
+        return $this;
+    }
+
+    /**
+     * @return ArrayCollection|Issue156ContactTelephoneNumber[]
+     */
+    public function getTelephoneNumbers()
+    {
+        return $this->telephoneNumbers;
+    }
+}

--- a/tests/SimpleThings/Tests/EntityAudit/Fixtures/Issue/Issue156ContactTelephoneNumber.php
+++ b/tests/SimpleThings/Tests/EntityAudit/Fixtures/Issue/Issue156ContactTelephoneNumber.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: david
+ * Date: 23/02/2016
+ * Time: 15:57
+ */
+
+namespace SimpleThings\EntityAudit\Tests\Fixtures\Issue;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Class Issue156ContactTelephoneNumber
+ * @package SimpleThings\EntityAudit\Tests\Fixtures\Issue
+ * @ORM\Entity()
+ */
+class Issue156ContactTelephoneNumber
+{
+    /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue(strategy="AUTO") */
+    protected $id;
+
+    /**
+     * @var Issue156Contact
+     * @ORM\ManyToOne(targetEntity="Issue156Contact", inversedBy="telephoneNumbers")
+     */
+    private $contact;
+
+    /**
+     * @var string
+     * @ORM\Column(type="string", length=255, nullable=false)
+     */
+    private $number;
+
+    /**
+     * @param mixed $id
+     * @return $this
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param Issue156Contact $contact
+     * @return $this
+     */
+    public function setContact(Issue156Contact $contact = null)
+    {
+        $this->contact = $contact;
+
+        return $this;
+    }
+
+    /**
+     * @return Issue156Contact
+     */
+    public function getContact()
+    {
+        return $this->contact;
+    }
+
+    /**
+     * @param string $number
+     * @return $this
+     */
+    public function setNumber($number)
+    {
+        $this->number = $number;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNumber()
+    {
+        return $this->number;
+    }
+}

--- a/tests/SimpleThings/Tests/EntityAudit/IssueTest.php
+++ b/tests/SimpleThings/Tests/EntityAudit/IssueTest.php
@@ -24,11 +24,15 @@
 
 namespace SimpleThings\EntityAudit\Tests;
 
+use SimpleThings\EntityAudit\AuditReader;
 use SimpleThings\EntityAudit\Tests\Fixtures\Issue\DuplicateRevisionFailureTestOwnedElement;
 use SimpleThings\EntityAudit\Tests\Fixtures\Issue\DuplicateRevisionFailureTestPrimaryOwner;
 use SimpleThings\EntityAudit\Tests\Fixtures\Issue\DuplicateRevisionFailureTestSecondaryOwner;
 use SimpleThings\EntityAudit\Tests\Fixtures\Issue\EscapedColumnsEntity;
 use SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue111Entity;
+use SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156Contact;
+use SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156ContactTelephoneNumber;
+use SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156Client;
 use SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue31Reve;
 use SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue31User;
 use SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue87Organization;
@@ -54,6 +58,9 @@ class IssueTest extends BaseTest
         'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue111Entity',
         'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue31User',
         'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue31Reve',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156Contact',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156ContactTelephoneNumber',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156Client',
     );
 
     protected $auditedEntities = array(
@@ -71,6 +78,9 @@ class IssueTest extends BaseTest
         'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue111Entity',
         'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue31User',
         'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue31Reve',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156Contact',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156ContactTelephoneNumber',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156Client',
     );
 
     public function testIssue31()
@@ -210,5 +220,21 @@ class IssueTest extends BaseTest
 
         $this->em->remove($primaryOwner);
         $this->em->flush();
+    }
+
+    public function testIssue156()
+    {
+        $client = new Issue156Client();
+
+        $number = new Issue156ContactTelephoneNumber();
+        $number->setNumber('0123567890');
+        $client->addTelephoneNumber($number);
+
+        $this->em->persist($client);
+        $this->em->persist($number);
+        $this->em->flush();
+
+        $auditReader = $this->auditManager->createAuditReader($this->em);
+        $object = $auditReader->find(get_class($number), $number->getId(), 1);
     }
 }


### PR DESCRIPTION
Addresses Issue #156, where AuditReader::find() fails to load entities belonging to a sub-class of a target entity using single-table-inheritance.