### PR TITLE
Use the audit-manager-service as factory for the audit_reader

### DIFF
--- a/src/SimpleThings/EntityAudit/Resources/config/auditable.xml
+++ b/src/SimpleThings/EntityAudit/Resources/config/auditable.xml
@@ -21,7 +21,7 @@
         </service>
 
         <service id="simplethings_entityaudit.reader" class="SimpleThings\EntityAudit\AuditReader">
-            <factory class="SimpleThings\EntityAudit\AuditManager" method="createAuditReader" />
+            <factory service="simplethings_entityaudit.manager" method="createAuditReader" />
             <argument type="service" id="doctrine.orm.default_entity_manager" />
         </service>
 


### PR DESCRIPTION
In SF 2.7.9, I updated the bundle and get the error:

Notice: Undefined property: appDevDebugProjectContainer::$config 
vendor/simplethings/entity-audit-bundle/src/SimpleThings/EntityAudit/AuditManager.php at line 44

This come from the factory syntax intruced by the commit 612416e

The service should be used instead of the class