### PR TITLE
Grab 'name' key from joinColumn in association mapping for column name.

### DIFF
--- a/src/SimpleThings/EntityAudit/AuditReader.php
+++ b/src/SimpleThings/EntityAudit/AuditReader.php
@@ -226,7 +226,7 @@ class AuditReader
             if (isset($class->fieldMappings[$idField])) {
                 $columnName = $class->fieldMappings[$idField]['columnName'];
             } elseif (isset($class->associationMappings[$idField])) {
-                $columnName = $class->associationMappings[$idField]['joinColumns'][0];
+                $columnName = $class->associationMappings[$idField]['joinColumns'][0]['name'];
             } else {
                 throw new \RuntimeException('column name not found  for' . $idField);
             }
@@ -676,7 +676,7 @@ class AuditReader
                 if ($whereSQL) {
                     $whereSQL .= " AND ";
                 }
-                $whereSQL .= "e." . $class->associationMappings[$idField]['joinColumns'][0] . " = ?";
+                $whereSQL .= "e." . $class->associationMappings[$idField]['joinColumns'][0]['name'] . " = ?";
             }
         }
 
@@ -729,7 +729,7 @@ class AuditReader
                 if ($whereSQL) {
                     $whereSQL .= " AND ";
                 }
-                $whereSQL .= "e." . $class->associationMappings[$idField]['joinColumns'][0] . " = ?";
+                $whereSQL .= "e." . $class->associationMappings[$idField]['joinColumns'][0]['name'] . " = ?";
             }
         }
 
@@ -808,7 +808,7 @@ class AuditReader
             if (isset($class->fieldMappings[$idField])) {
                 $columnName = $class->fieldMappings[$idField]['columnName'];
             } else if (isset($class->associationMappings[$idField])) {
-                $columnName = $class->associationMappings[$idField]['joinColumns'][0];
+                $columnName = $class->associationMappings[$idField]['joinColumns'][0]['name'];
             } else {
                 continue;
             }

--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -150,7 +150,7 @@ class LogRevisionsListener implements EventSubscriber
                         $columnName = $meta->fieldMappings[$idField]['columnName'];
                         $types[] = $meta->fieldMappings[$idField]['type'];
                     } elseif (isset($meta->associationMappings[$idField])) {
-                        $columnName = $meta->associationMappings[$idField]['joinColumns'][0];
+                        $columnName = $meta->associationMappings[$idField]['joinColumns'][0]['name'];
                         $types[] = $meta->associationMappings[$idField]['type'];
                     }
 


### PR DESCRIPTION
Each element in the joinColumns array in an association mapping is an associative array. When pulling out the column name, it needs to access array key 'name'.