### PR TITLE
Fix: the entity must be search by the ids instead of the identifiers

### DIFF
--- a/src/SimpleThings/EntityAudit/AuditReader.php
+++ b/src/SimpleThings/EntityAudit/AuditReader.php
@@ -222,15 +222,7 @@ class AuditReader
 
         $whereSQL  = "e." . $this->config->getRevisionFieldName() ." <= ?";
 
-        foreach ($class->identifier AS $idField) {
-            if (isset($class->fieldMappings[$idField])) {
-                $columnName = $class->fieldMappings[$idField]['columnName'];
-            } elseif (isset($class->associationMappings[$idField])) {
-                $columnName = $class->associationMappings[$idField]['joinColumns'][0];
-            } else {
-                throw new \RuntimeException('column name not found  for' . $idField);
-            }
-
+        foreach (array_keys($id) AS $columnName) {
             $whereSQL .= " AND e." . $columnName . " = ?";
         }
 


### PR DESCRIPTION
The entities must be search by the ids and not the identifiers.
The id array contains the column_name and not the field_name.
So the whereSql have to use directly the column_name given.

The issue:
There is an audtited entity A that have an OneToOne audited entity B
The B entity has the owningSide.

When the A is loaded, it tries to load the B but an Error is thrown.

The id parameter of the find function contains (a_id => XXX) but the whereSql is set with the string "and id = XXX" instead of "a_id = XXX"
