### PR TITLE
AuditedCollection renames indexBy value and then use it. That avoids …

### DIFF
--- a/src/SimpleThings/EntityAudit/Collection/AuditedCollection.php
+++ b/src/SimpleThings/EntityAudit/Collection/AuditedCollection.php
@@ -448,7 +448,7 @@ class AuditedCollection implements Collection
             $sql .= $this->configuration->getRevisionTypeFieldName().' AS revtype, ';
             $sql .= implode(', ', $this->metadata->getIdentifierColumnNames()).' ';
             if (isset($this->associationDefinition['indexBy'])) {
-                $sql .= ', '.$this->associationDefinition['indexBy'].' ';
+                $sql .= ', '.$this->associationDefinition['indexBy'].' AS __indexBy ';
             }
             $sql .= 'FROM ' . $this->configuration->getTableName($this->metadata) . ' t ';
             $sql .= 'WHERE ' . $this->configuration->getRevisionFieldName() . ' <= ' . $this->revision . ' ';
@@ -522,8 +522,8 @@ class AuditedCollection implements Collection
                 $entity['keys'] = $row;
 
                 if (isset($this->associationDefinition['indexBy'])) {
-                    $key = $row[$this->associationDefinition['indexBy']];
-                    unset($entity['keys'][$this->associationDefinition['indexBy']]);
+                    $key = $row['__indexBy'];
+                    unset($entity['keys']['__indexBy']);
                     $this->entities[$key] = $entity;
                 } else {
                     $this->entities[] = $entity;


### PR DESCRIPTION
…name collisions between loaded entity identifiers and indexation settings on association.
