### PR TITLE
fix: use the type of association fields in LogRevisionsListener

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -141,6 +141,8 @@ class LogRevisionsListener implements EventSubscriber
                             sprintf('Could not resolve database type for column "%s" during extra updates', $field)
                         );
                     }
+                    
+                    $types[] = $type;
                 }
 
                 $types[] = $this->config->getRevisionIdFieldType();

--- a/tests/SimpleThings/Tests/EntityAudit/Fixtures/Issue/Issue198Car.php
+++ b/tests/SimpleThings/Tests/EntityAudit/Fixtures/Issue/Issue198Car.php
@@ -1,0 +1,43 @@
+<?php
+namespace SimpleThings\EntityAudit\Tests\Fixtures\Issue;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Issue198Car
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="guid")
+     * @ORM\GeneratedValue(strategy="UUID")
+     */
+    protected $id;
+    
+    /**
+     * @ORM\ManyToOne(targetEntity="Issue198Owner", inversedBy="cars")
+     * @ORM\JoinColumn(name="owner_id", referencedColumnName="id")
+     */
+    protected $owner;
+    
+    public function getId()
+    {
+        return $this->id;
+    }
+    
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+    
+    public function getOwner()
+    {
+        return $this->owner;
+    }
+    
+    public function setOwner(Issue198Owner $owner)
+    {
+        $this->owner = $owner;
+    }
+}

--- a/tests/SimpleThings/Tests/EntityAudit/Fixtures/Issue/Issue198Owner.php
+++ b/tests/SimpleThings/Tests/EntityAudit/Fixtures/Issue/Issue198Owner.php
@@ -1,0 +1,56 @@
+<?php
+namespace SimpleThings\EntityAudit\Tests\Fixtures\Issue;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @ORM\Entity()
+ */
+class Issue198Owner
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="guid")
+     * @ORM\GeneratedValue(strategy="UUID")
+     */
+    protected $id;
+    
+    /**
+     * @ORM\OneToMany(targetEntity="Issue198Car", mappedBy="owner")
+     */
+    protected $cars;
+    
+    public function __construct()
+    {
+        $this->cars = new ArrayCollection();
+    }
+    
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+    
+    public function getId()
+    {
+        return $this->id;
+    }
+    
+    public function addCar(Issue198Car $car)
+    {
+        if (!$this->cars->contains($car)) {
+            $car->setOwner($this);
+            $this->cars[] = $car;
+        }
+    }
+    
+    public function removeCar(Issue198Car $car)
+    {
+        $this->cars->removeElement($car);
+    }
+    
+    public function getCars()
+    {
+        return $this->cars;
+    }
+}

--- a/tests/SimpleThings/Tests/EntityAudit/IssueTest.php
+++ b/tests/SimpleThings/Tests/EntityAudit/IssueTest.php
@@ -40,6 +40,8 @@ use SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue87Project;
 use SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue87ProjectComment;
 use SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue9Address;
 use SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue9Customer;
+use SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue198Owner;
+use SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue198Car;
 
 class IssueTest extends BaseTest
 {
@@ -61,6 +63,8 @@ class IssueTest extends BaseTest
         'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156Contact',
         'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156ContactTelephoneNumber',
         'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156Client',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue198Car',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue198Owner',
     );
 
     protected $auditedEntities = array(
@@ -81,6 +85,8 @@ class IssueTest extends BaseTest
         'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156Contact',
         'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156ContactTelephoneNumber',
         'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue156Client',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue198Car',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Issue\Issue198Owner',
     );
 
     public function testIssue31()
@@ -236,5 +242,29 @@ class IssueTest extends BaseTest
 
         $auditReader = $this->auditManager->createAuditReader($this->em);
         $object = $auditReader->find(get_class($number), $number->getId(), 1);
+    }
+    
+    public function testIssue198()
+    {
+        $owner = new Issue198Owner();
+        $car = new Issue198Car();
+        
+        $this->em->persist($owner);
+        $this->em->persist($car);
+        $this->em->flush();
+        
+        $owner->addCar($car);
+
+        $this->em->persist($owner);
+        $this->em->persist($car);
+        $this->em->flush();
+
+        $auditReader = $this->auditManager->createAuditReader($this->em);
+        
+        $car1 = $auditReader->find(get_class($car), $car->getId(), 1);
+        $this->assertNull($car1->getOwner());
+        
+        $car2 = $auditReader->find(get_class($car), $car->getId(), 2);
+        $this->assertEquals($car2->getOwner()->getId(), $owner->getId());
     }
 }


### PR DESCRIPTION
When building the "UPDATE" query in postFlush, LogRevisionsListener
computes the type of each field to update. When the field was an association
field, the type was not used in the call of Connection::executeQuery, causing
the UPDATE query to fail.

This commit simply adds the computed type in the "types" array