### PR TITLE
Rename global_ignore_columns to global_ignore_properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ If you need to exclude some entity properties from triggering a revision use:
 #####app/config/config.yml
 ```yml
 simple_things_entity_audit:
-    global_ignore_columns:
-        - created_at
-        - updated_at
+    global_ignore_properties:
+        - createdAt
+        - updatedAt
 ```
 
 ###Creating new tables
@@ -103,9 +103,9 @@ $auditconfig->setAuditedEntityClasses(array(
     'SimpleThings\EntityAudit\Tests\UserAudit'
 ));
 
-$auditconfig->setGlobalIgnoreColumns(array(
-    'created_at',
-    'updated_at'
+$auditconfig->setGlobalIgnoreProperties(array(
+    'createdAt',
+    'updatedAt'
 ));
 
 $evm = new EventManager();

--- a/src/SimpleThings/EntityAudit/AuditConfiguration.php
+++ b/src/SimpleThings/EntityAudit/AuditConfiguration.php
@@ -28,7 +28,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 class AuditConfiguration
 {
     private $auditedEntityClasses = array();
-    private $globalIgnoreColumns = array();
+    private $globalIgnoreProperties = array();
     private $tablePrefix = '';
     private $tableSuffix = '_audit';
     private $revisionTableName = 'revisions';
@@ -122,14 +122,14 @@ class AuditConfiguration
         $this->auditedEntityClasses = $classes;
     }
 
-    public function getGlobalIgnoreColumns()
+    public function getGlobalIgnoreProperties()
     {
-        return $this->globalIgnoreColumns;
+        return $this->globalIgnoreProperties;
     }
 
-    public function setGlobalIgnoreColumns(array $columns)
+    public function setGlobalIgnoreProperties(array $properties)
     {
-        $this->globalIgnoreColumns = $columns;
+        $this->globalIgnoreProperties = $properties;
     }
 
     public function createMetadataFactory()

--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -152,7 +152,7 @@ class LogRevisionsListener implements EventSubscriber
                             sprintf('Could not resolve database type for column "%s" during extra updates', $column)
                         );
                     }
-                    
+
                     $types[] = $type;
                 }
 
@@ -202,9 +202,9 @@ class LogRevisionsListener implements EventSubscriber
 
         // get changes => should be already computed here (is a listener)
         $changeset = $this->uow->getEntityChangeSet($entity);
-        foreach ($this->config->getGlobalIgnoreColumns() as $column) {
-            if (isset($changeset[$column])) {
-                unset($changeset[$column]);
+        foreach ($this->config->getGlobalIgnoreProperties() as $property) {
+            if (isset($changeset[$property])) {
+                unset($changeset[$property]);
             }
         }
 

--- a/src/SimpleThings/EntityAudit/Resources/config/auditable.xml
+++ b/src/SimpleThings/EntityAudit/Resources/config/auditable.xml
@@ -43,8 +43,8 @@
             <call method="setAuditedEntityClasses">
                 <argument>%simplethings.entityaudit.audited_entities%</argument>
             </call>
-            <call method="setGlobalIgnoreColumns">
-                <argument>%simplethings.entityaudit.global_ignore_columns%</argument>
+            <call method="setGlobalIgnoreProperties">
+                <argument>%simplethings.entityaudit.global_ignore_properties%</argument>
             </call>
             <call method="setTablePrefix">
                 <argument>%simplethings.entityaudit.table_prefix%</argument>

--- a/tests/SimpleThings/Tests/EntityAudit/BaseTest.php
+++ b/tests/SimpleThings/Tests/EntityAudit/BaseTest.php
@@ -189,7 +189,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
         }
 
         $auditConfig = AuditConfiguration::forEntities($this->auditedEntities);
-        $auditConfig->setGlobalIgnoreColumns(array('ignoreme'));
+        $auditConfig->setGlobalIgnoreProperties(array('ignoreMe'));
         $auditConfig->setUsernameCallable(function () {
             return 'beberlei';
         });

--- a/tests/SimpleThings/Tests/EntityAudit/CoreTest.php
+++ b/tests/SimpleThings/Tests/EntityAudit/CoreTest.php
@@ -286,7 +286,7 @@ class CoreTest extends BaseTest
         $this->assertEquals(3, $revision);
     }
 
-    public function testGlobalIgnoreColumns()
+    public function testGlobalIgnoreProperties()
     {
         $user = new UserAudit("welante");
         $article = new ArticleAudit("testcolumn", "yadda!", $user, 'text');
@@ -304,7 +304,7 @@ class CoreTest extends BaseTest
         $revision = $reader->getCurrentRevision(get_class($article), $article->getId());
         $this->assertEquals(2, $revision);
 
-        $article->setIgnoreme("textnew");
+        $article->setIgnoreMe("textnew");
         $this->em->persist($article);
         $this->em->flush();
 
@@ -341,14 +341,14 @@ class CoreTest extends BaseTest
         $this->auditManager->getConfiguration()->setUsernameCallable(function () {
             return 'user: ' . uniqid();
         });
-        
+
         $user = new UserAudit('beberlei');
         $this->em->persist($user);
         $this->em->flush();
-        
+
         $user->setName('b.eberlei');
         $this->em->flush();
-        
+
         $reader = $this->auditManager->createAuditReader($this->em);
         $revisions = $reader->findRevisionHistory();
 

--- a/tests/SimpleThings/Tests/EntityAudit/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
+++ b/tests/SimpleThings/Tests/EntityAudit/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
@@ -30,7 +30,7 @@ class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasService('simplethings_entityaudit.config', 'SimpleThings\EntityAudit\AuditConfiguration');
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setAuditedEntityClasses', array('%simplethings.entityaudit.audited_entities%'));
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setGlobalIgnoreColumns', array('%simplethings.entityaudit.global_ignore_columns%'));
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setGlobalIgnoreProperties', array('%simplethings.entityaudit.global_ignore_properties%'));
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setTablePrefix', array('%simplethings.entityaudit.table_prefix%'));
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setTableSuffix', array('%simplethings.entityaudit.table_suffix%'));
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setRevisionTableName', array('%simplethings.entityaudit.revision_table_name%'));

--- a/tests/SimpleThings/Tests/EntityAudit/Fixtures/Core/ArticleAudit.php
+++ b/tests/SimpleThings/Tests/EntityAudit/Fixtures/Core/ArticleAudit.php
@@ -19,17 +19,17 @@ class ArticleAudit
     private $text;
 
     /** @ORM\Column(type="text") */
-    private $ignoreme;
+    private $ignoreMe;
 
     /** @ORM\ManyToOne(targetEntity="UserAudit") */
     private $author;
 
-    function __construct($title, $text, $author, $ignoreme)
+    function __construct($title, $text, $author, $ignoreMe)
     {
         $this->title    = $title;
         $this->text     = $text;
         $this->author   = $author;
-        $this->ignoreme = $ignoreme;
+        $this->ignoreMe = $ignoreMe;
     }
 
     public function getId()
@@ -42,8 +42,8 @@ class ArticleAudit
         $this->text = $text;
     }
 
-    public function setIgnoreme($ignoreme)
+    public function setIgnoreMe($ignoreMe)
     {
-        $this->ignoreme = $ignoreme;
+        $this->ignoreMe = $ignoreMe;
     }
 }


### PR DESCRIPTION
**Replaces #189 because of a bad rebase.**

When reading the documentation

``` yml
# If you need to exclude some entity properties from triggering a revision use:

simple_things_entity_audit:
    global_ignore_columns:
        - created_at
        - updated_at
```

one would assume that you need to specify the name of your actual database table columns in order to ignore changes for them. However, the `LogRevisionsListener` watches for changes on entity properties (property names) not on the database field names (see #135).

The proposed change is to make the configuration as such:

``` yml
simple_things_entity_audit:
    global_ignore_properties:
        - createdAt
        - updatedAt
```

`global_ignore_columns` should rather be called `global_ignore_properties`. I've also updated the tests to reflect this. Since camelCased properties were never tested so the tests never failed.

**Important**: this is a BC-change, so a new version should be tagged accordingly. Or even better: if someone knows a way to support both, but mark the `global_ignore_columns` option as deprecated, feel free to chip in.
