### PR TITLE
Support for entities annotations

### DIFF
--- a/src/SimpleThings/EntityAudit/AuditConfigurationFactory.php
+++ b/src/SimpleThings/EntityAudit/AuditConfigurationFactory.php
@@ -3,13 +3,20 @@
 namespace SimpleThings\EntityAudit;
 
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Configuration;
 
 class AuditConfigurationFactory
 {
     const ANNOTATION_AUDITABLE = 'SimpleThings\\EntityAudit\\Mapping\\Annotation\\Auditable';
 
+    /**
+     * This is the factory method used by the Symfony DependencyInjection
+     *
+     * @param Configuration $doctrineConfiguration
+     * @param Reader $reader
+     * @param array $auditedEntities
+     * @return AuditConfiguration
+     */
     public function createAuditConfiguration(Configuration $doctrineConfiguration, Reader $reader, $auditedEntities = array())
     {
         $entities = $doctrineConfiguration

--- a/src/SimpleThings/EntityAudit/AuditConfigurationFactory.php
+++ b/src/SimpleThings/EntityAudit/AuditConfigurationFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SimpleThings\EntityAudit;
+
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\Configuration;
+
+class AuditConfigurationFactory
+{
+    const ANNOTATION_AUDITABLE = 'SimpleThings\\EntityAudit\\Mapping\\Annotation\\Auditable';
+
+    public function createAuditConfiguration(Configuration $doctrineConfiguration, Reader $reader, $auditedEntities = array())
+    {
+        $entities = $doctrineConfiguration
+            ->getMetadataDriverImpl()
+            ->getAllClassNames();
+
+        foreach ($entities as $entity) {
+            if ($reader->getClassAnnotation(new \ReflectionClass($entity), self::ANNOTATION_AUDITABLE) && !in_array($entity, $auditedEntities)) {
+                $auditedEntities[] = $entity;
+            }
+        }
+
+        return AuditConfiguration::forEntities($auditedEntities);
+    }
+}

--- a/src/SimpleThings/EntityAudit/DependencyInjection/Configuration.php
+++ b/src/SimpleThings/EntityAudit/DependencyInjection/Configuration.php
@@ -11,6 +11,13 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder();
         $builder->root('simple_things_entity_audit')
+            ->beforeNormalization()
+                ->ifTrue(function ($v) { return isset($v['audited_entities']); })
+                ->then(function ($v) {
+                    @trigger_error('The audited_entities configuration key is deprecated. Use the annotations instead.', E_USER_DEPRECATED);
+                    return $v;
+                })
+            ->end()
             ->children()
                 ->arrayNode('audited_entities')
                     ->prototype('scalar')->end()

--- a/src/SimpleThings/EntityAudit/DependencyInjection/Configuration.php
+++ b/src/SimpleThings/EntityAudit/DependencyInjection/Configuration.php
@@ -11,13 +11,6 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder();
         $builder->root('simple_things_entity_audit')
-            ->beforeNormalization()
-                ->ifTrue(function ($v) { return isset($v['audited_entities']); })
-                ->then(function ($v) {
-                    @trigger_error('The audited_entities configuration key is deprecated. Use the annotations instead.', E_USER_DEPRECATED);
-                    return $v;
-                })
-            ->end()
             ->children()
                 ->arrayNode('audited_entities')
                     ->prototype('scalar')->end()

--- a/src/SimpleThings/EntityAudit/Mapping/Annotation/Auditable.php
+++ b/src/SimpleThings/EntityAudit/Mapping/Annotation/Auditable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SimpleThings\EntityAudit\Mapping\Annotation;
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * Auditable annotation
+ *
+ * @Annotation
+ * @Target("CLASS")
+ */
+final class Auditable extends Annotation
+{
+
+}

--- a/src/SimpleThings/EntityAudit/Resources/config/auditable.xml
+++ b/src/SimpleThings/EntityAudit/Resources/config/auditable.xml
@@ -39,7 +39,14 @@
             <argument id="service_container" type="service" />
         </service>
 
+        <service id="simplethings_entityaudit.config_factory" class="SimpleThings\EntityAudit\AuditConfigurationFactory">
+        </service>
+
         <service id="simplethings_entityaudit.config" class="SimpleThings\EntityAudit\AuditConfiguration">
+            <factory service="simplethings_entityaudit.config_factory" method="createAuditConfiguration" />
+            <argument type="service" id="doctrine.orm.default_configuration" />
+            <argument type="service" id="annotation_reader" />
+            <argument>%simplethings.entityaudit.audited_entities%</argument>
             <call method="setAuditedEntityClasses">
                 <argument>%simplethings.entityaudit.audited_entities%</argument>
             </call>
@@ -70,4 +77,3 @@
         </service>
     </services>
 </container>
-

--- a/tests/SimpleThings/Tests/EntityAudit/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
+++ b/tests/SimpleThings/Tests/EntityAudit/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
@@ -31,6 +31,10 @@ class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService('simplethings_entityaudit.config', 'SimpleThings\EntityAudit\AuditConfiguration');
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setAuditedEntityClasses', array('%simplethings.entityaudit.audited_entities%'));
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setGlobalIgnoreProperties', array('%simplethings.entityaudit.global_ignore_properties%'));
+        $this->assertContainerBuilderHasServiceDefinitionFactory('simplethings_entityaudit.config', 'simplethings_entityaudit.config_factory', 'createAuditConfiguration');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('simplethings_entityaudit.config', 0, 'doctrine.orm.default_configuration');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('simplethings_entityaudit.config', 1, 'annotation_reader');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('simplethings_entityaudit.config', 2, '%simplethings.entityaudit.audited_entities%');
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setTablePrefix', array('%simplethings.entityaudit.table_prefix%'));
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setTableSuffix', array('%simplethings.entityaudit.table_suffix%'));
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setRevisionTableName', array('%simplethings.entityaudit.revision_table_name%'));
@@ -109,5 +113,22 @@ class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCase
         return array(
             new SimpleThingsEntityAuditExtension(),
         );
+    }
+
+    /**
+     * Assert that the ContainerBuilder for this test has a service definition with the given id, which has a factory
+     * definition with the given arguments.
+     *
+     * @param string $serviceId
+     * @param string $factoryId
+     * @param string $factoryMethod
+     */
+    protected function assertContainerBuilderHasServiceDefinitionFactory($serviceId, $factoryId, $factoryMethod)
+    {
+        $definition = $this->container->findDefinition($serviceId);
+        $factory = $definition->getFactory();
+
+        $this->assertEquals($factoryId, (string)$factory[0]);
+        $this->assertEquals($factoryMethod, $factory[1]);
     }
 }


### PR DESCRIPTION
I added an Auditable annotation for entities.

```
<?php
...
use SimpleThings\EntityAudit\Mapping\Annotation as Audit;

/**
 * @ORM\Entity()
 * @Audit\Auditable
 */
class TestAudit {
```

Annotated entities are merged into the audited_entities array.

IMO, we should advise to use annotations instead of the global configuration in app/config/config.yml, this is why I added a deprecated message when the configuration key "audited_entities" is set.

For avoiding BC breaks, I had to wrap the AuditConfiguration service with a factory, I updated the SimpleThingsEntityAuditExtensionTest correspondingly.

---

Tests are passing, if this is something you would want to merge, I can add more tests on annotated entities.

---

Fixes #20 
