### PR TITLE
Fallback to native entity if no revision found for properties

### DIFF
--- a/src/SimpleThings/EntityAudit/AuditReader.php
+++ b/src/SimpleThings/EntityAudit/AuditReader.php
@@ -443,6 +443,9 @@ class AuditReader
                                 $value = $this->find($targetClass->name, $pk, $revision, array('threatDeletionsAsExceptions' => true));
                             } catch (DeletedException $e) {
                                 $value = null;
+                            } catch (NoRevisionFoundException $e) {
+                                // The entity does not have any revision yet. So let's get the actual state of it.
+                                $value = $this->em->find($targetClass->name, $pk);
                             }
 
                             $class->reflFields[$field]->setValue($entity, $value);

--- a/tests/SimpleThings/Tests/EntityAudit/Fixtures/Core/ArticleAudit.php
+++ b/tests/SimpleThings/Tests/EntityAudit/Fixtures/Core/ArticleAudit.php
@@ -37,6 +37,11 @@ class ArticleAudit
         return $this->id;
     }
 
+    public function getAuthor()
+    {
+        return $this->author;
+    }
+
     public function setText($text)
     {
         $this->text = $text;


### PR DESCRIPTION
If an audited entity has relational properties, the reader will try to find them as the same version, or previous.

But if the targeted class does not has any revision at all, this produces a NoRevisionFound exception.

This should be catched and should fallback to a classic doctrine find query.

Concrete error with stack trace:

```
No revision of class 'AppBundle\Entity\User' (1) was found at revision 7 or before. The entity did not exist at the specified revision yet.

in vendor/simplethings/entity-audit-bundle/src/SimpleThings/EntityAudit/AuditReader.php at line 322   + 
at AuditReader ->find ('AppBundle\Entity\User', array('id' => '1'), '7', array('threatDeletionsAsExceptions' => true)) 
in vendor/simplethings/entity-audit-bundle/src/SimpleThings/EntityAudit/AuditReader.php at line 443   + 
at AuditReader ->createEntity ('AppBundle\Entity\Ticket', array('id' => 'id', 'title' => 'title', 'addedAt' => 'added_at', 'updatedAt' => 'updated_at', 'assignedAt' => 'assigned_at', 'closedAt' => 'closed_at', 'priority' => 'priority', 'state' => 'state', 'awaitingAnswerReminded' => 'awaiting_answer_reminded', 'feedbackScore' => 'feedback_score', 'feedbackComment' => 'feedback_comment', 'feedbackDoneAt' => 'feedback_done_at', 'awaitingFeedbackReminded' => 'awaiting_feedback_reminded', 'category_id' => 'category_id', 'author_id' => 'author_id', 'assigned_id' => 'assigned_id', 'organization_id' => 'organization_id', 'server_id' => 'server_id'), array('id' => '526', 'title' => 'Ticket de test Behat', 'addedAt' => '2016-10-01 14:45:00', 'updatedAt' => '2016-10-04 11:33:45', 'assignedAt' => null, 'closedAt' => null, 'priority' => '2', 'state' => '0', 'awaitingAnswerReminded' => '0', 'feedbackScore' => null, 'feedbackComment' => null, 'feedbackDoneAt' => null, 'awaitingFeedbackReminded' => '0', 'category_id' => '1', 'author_id' => '1', 'assigned_id' => null, 'organization_id' => null, 'server_id' => '1'), '7') 
in vendor/simplethings/entity-audit-bundle/src/SimpleThings/EntityAudit/AuditReader.php at line 331   + 
at AuditReader ->find ('AppBundle\Entity\Ticket', array('id' => '526'), '7') 
in src/AppBundle/Manager/TicketManager.php at line 250   + 
at TicketManager ->getTimeLine (object(Ticket)) 
in src/AppBundle/Controller/TicketController.php at line 259   + 
at TicketController ->showAction (object(Request), object(Ticket)) 
at call_user_func_array (array(object(TicketController), 'showAction'), array(object(Request), object(Ticket))) 
in vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php at line 144   + 
at HttpKernel ->handleRaw (object(Request), '1') 
in vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php at line 64   + 
at HttpKernel ->handle (object(Request), '1', true) 
in vendor/symfony/symfony/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php at line 69   + 
at ContainerAwareHttpKernel ->handle (object(Request), '1', true) 
in vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php at line 185   + 
at Kernel ->handle (object(Request)) 
in web/app_dev.php at line 34   +
```

Basically, the reader try to find a `User` instance of a specified revision because it's a property of the `Ticket` instance.

But after a fresh deploy, existing `User` instances does not has any revision yet.

Could you please push a new patch release after merging this? This is quite critical.

Regards.

fix #157