### PR TITLE
Enable join column to be an id

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -24,6 +24,7 @@
 namespace SimpleThings\EntityAudit\EventListener;
 
 use Doctrine\Common\EventSubscriber;
+use Doctrine\Common\Persistence\Mapping\MappingException;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\OnFlushEventArgs;
@@ -98,6 +99,13 @@ class LogRevisionsListener implements EventSubscriber
         return array(Events::onFlush, Events::postPersist, Events::postUpdate, Events::postFlush);
     }
 
+    /**
+     * @param PostFlushEventArgs $eventArgs
+     * @throws MappingException
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws MappingException
+     * @throws \Exception
+     */
     public function postFlush(PostFlushEventArgs $eventArgs)
     {
         $em = $eventArgs->getEntityManager();
@@ -172,6 +180,14 @@ class LogRevisionsListener implements EventSubscriber
                         $types[] = $meta->fieldMappings[$idField]['type'];
                     } elseif (isset($meta->associationMappings[$idField])) {
                         $columnName = $meta->associationMappings[$idField]['joinColumns'][0];
+                        if (is_array($columnName)) {
+                            if (isset($columnName['name'])) {
+                                $columnName = $columnName['name'];
+                            } else {
+                                // Not much we can do to recover this - we need a column name...
+                                throw new MappingException('Column name not set within meta');
+                            }
+                        }
                         $types[] = $meta->associationMappings[$idField]['type'];
                     }
 

--- a/tests/SimpleThings/Tests/EntityAudit/Fixtures/Relation/Page.php
+++ b/tests/SimpleThings/Tests/EntityAudit/Fixtures/Relation/Page.php
@@ -16,6 +16,16 @@ class Page
     /** @ORM\OneToMany(targetEntity="PageLocalization", mappedBy="page", indexBy="locale") */
     private $localizations;
 
+
+    /**
+     * A page can have many aliases
+     *
+     * @var PageAlias[]
+     * @ORM\OneToMany(targetEntity="PageAlias", mappedBy="page", cascade={"persist"})
+     */
+    protected $pageAliases;
+
+
     public function __construct()
     {
         $this->localizations = new ArrayCollection();
@@ -35,5 +45,13 @@ class Page
     {
         $localization->setPage($this);
         $this->localizations->set($localization->getLocale(), $localization);
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->id;
     }
 }

--- a/tests/SimpleThings/Tests/EntityAudit/Fixtures/Relation/PageAlias.php
+++ b/tests/SimpleThings/Tests/EntityAudit/Fixtures/Relation/PageAlias.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: doconnell
+ * Date: 12/10/16
+ * Time: 08:49
+ */
+
+namespace SimpleThings\EntityAudit\Tests\Fixtures\Relation;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A slightly contrived entity which has an entity (Page) as an ID.
+ * @ORM\Entity
+ */
+class PageAlias
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="Page", inversedBy="associatedEmails", cascade={"persist"})
+     * @ORM\JoinColumn(name="page_id", referencedColumnName="id", nullable=false)
+     * @ORM\Id
+     * @var Page
+     */
+    protected $page;
+
+    /**
+     * @var string
+     * @ORM\Column( type="string", nullable=false, length=255, unique=true)
+     * )
+     */
+    protected $alias;
+
+    public function __construct(Page $page, $alias = null)
+    {
+        $this->page = $page;
+        $this->alias = $alias;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAlias()
+    {
+        return $this->alias;
+    }
+
+    /**
+     * @param string $alias
+     * @return self
+     */
+    public function setAlias($alias)
+    {
+        $this->alias = $alias;
+        return $this;
+    }
+}

--- a/tests/SimpleThings/Tests/EntityAudit/RelationTest.php
+++ b/tests/SimpleThings/Tests/EntityAudit/RelationTest.php
@@ -34,6 +34,7 @@ use SimpleThings\EntityAudit\Tests\Fixtures\Relation\OwnedEntity2;
 use SimpleThings\EntityAudit\Tests\Fixtures\Relation\OwnedEntity3;
 use SimpleThings\EntityAudit\Tests\Fixtures\Relation\OwnerEntity;
 use SimpleThings\EntityAudit\Tests\Fixtures\Relation\Page;
+use SimpleThings\EntityAudit\Tests\Fixtures\Relation\PageAlias;
 use SimpleThings\EntityAudit\Tests\Fixtures\Relation\PageLocalization;
 use SimpleThings\EntityAudit\Tests\Fixtures\Relation\RelationFoobarEntity;
 use SimpleThings\EntityAudit\Tests\Fixtures\Relation\RelationOneToOneEntity;
@@ -55,6 +56,7 @@ class RelationTest extends BaseTest
         'SimpleThings\EntityAudit\Tests\Fixtures\Relation\WineProduct',
         'SimpleThings\EntityAudit\Tests\Fixtures\Relation\CheeseProduct',
         'SimpleThings\EntityAudit\Tests\Fixtures\Relation\Page',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Relation\PageAlias',
         'SimpleThings\EntityAudit\Tests\Fixtures\Relation\PageLocalization',
         'SimpleThings\EntityAudit\Tests\Fixtures\Relation\RelationOneToOneEntity',
         'SimpleThings\EntityAudit\Tests\Fixtures\Relation\RelationFoobarEntity',
@@ -72,6 +74,7 @@ class RelationTest extends BaseTest
         'SimpleThings\EntityAudit\Tests\Fixtures\Relation\WineProduct',
         'SimpleThings\EntityAudit\Tests\Fixtures\Relation\CheeseProduct',
         'SimpleThings\EntityAudit\Tests\Fixtures\Relation\Page',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Relation\PageAlias',
         'SimpleThings\EntityAudit\Tests\Fixtures\Relation\PageLocalization',
         'SimpleThings\EntityAudit\Tests\Fixtures\Relation\RelationOneToOneEntity',
         'SimpleThings\EntityAudit\Tests\Fixtures\Relation\RelationFoobarEntity',
@@ -778,5 +781,20 @@ class RelationTest extends BaseTest
 
         $this->assertEquals('foobar', $auditedBase->getReferencedEntity()->getFoobarField());
         $this->assertEquals('referenced', $auditedBase->getReferencedEntity()->getReferencedField());
+    }
+
+    /**
+     * Specific test for the case where a join condition is via an ORM/Id and where the column is also an object.
+     * Used to result in an 'aray to string conversion' error
+     */
+    public function testJoinOnObject()
+    {
+        $page = new Page();
+        $this->em->persist($page);
+        $this->em->flush();
+
+        $pageAlias = new PageAlias($page, 'This is the alias');
+        $this->em->persist($pageAlias);
+        $this->em->flush();
     }
 }


### PR DESCRIPTION
Where join annotations specify an @ORM/JoinColumn with name etc, the meta is an array, not string. Fixes 'Array to string conversion' error.

Given an attribute like this:

    /**
     * @ORM\OneToOne(targetEntity="User", inversedBy="userInfo")
     * @ORM\JoinColumn(name="user_id", referencedColumnName="id")
     * @ORM\Id
     * @var User
     */
    protected $user;

You will get an `Array to string conversion` error like this:

    Array to string conversion
    
    /home/doconnell/projects/fums/vendor/simplethings/entity-audit-bundle/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php:181
    /home/doconnell/projects/fums/vendor/symfony/symfony/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php:63
    /home/doconnell/projects/fums/vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php:3325
    /home/doconnell/projects/fums/vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php:427
    /home/doconnell/projects/fums/vendor/doctrine/orm/lib/Doctrine/ORM/EntityManager.php:356

That's because the `joinColumns` entry is presumed to be a string, which is not the case when the join column specifies associations.