### PR TITLE
Drop php < 5.6 & symfony < 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,9 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - nightly
   - hhvm
 
@@ -38,9 +36,9 @@ script: ./vendor/bin/phpunit -c tests/travis/$DB.travis.xml
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
+    - php: 5.6
       env: COMPOSER_FLAGS="--prefer-lowest" DB=sqlite
-    - php: 7.0
+    - php: 7.1
       env: NAME="MySQL 5.6" DB=mysql
       dist: trusty
       sudo: required
@@ -50,18 +48,18 @@ matrix:
           - mysql-server-5.6
           - mysql-client-core-5.6
           - mysql-client-5.6
-    - php: 7.0
+    - php: 7.1
       env: NAME="MySQL 5.7" DB=mysql MYSQL_VERSION=5.7
       sudo: required
-    - php: 7.0
+    - php: 7.1
       env: NAME="PostgreSQL 9.2" DB=pgsql
       addons:
         postgresql: 9.2
-    - php: 7.0
+    - php: 7.1
       env: NAME="PostgreSQL 9.3" DB=pgsql
       addons:
         postgresql: 9.3
-    - php: 7.0
+    - php: 7.1
       env: NAME="PostgreSQL 9.4" DB=pgsql
       addons:
         postgresql: 9.4

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
         "gedmo/doctrine-extensions": "^2.3.1",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "phpunit/phpunit": "^5.5",
-        "symfony/framework-bundle": "~2.7|~3.0",
-        "symfony/var-dumper": "^2.7",
+        "symfony/framework-bundle": "~2.8|~3.0",
+        "symfony/var-dumper": "~2.8|~3.0",
         "fabpot/php-cs-fixer": "^1.11"
     },
     "conflict": {
         "gedmo/doctrine-extensions": "<2.3.1",
-        "symfony/framework-bundle": "<2.7",
+        "symfony/framework-bundle": "<2.8",
         "doctrine/doctrine-bundle": "<1.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "description": "Audit for Doctrine Entities",
     "require": {
-        "php": "^5.3.9|~7.0",
+        "php": "^5.6|~7.0",
         "doctrine/dbal": "~2.5",
         "doctrine/orm": "~2.4"
     },
@@ -16,7 +16,7 @@
         "doctrine/doctrine-bundle": "~1.4",
         "gedmo/doctrine-extensions": "^2.3.1",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^5.5",
         "symfony/framework-bundle": "~2.7|~3.0",
         "symfony/var-dumper": "^2.7",
         "fabpot/php-cs-fixer": "^1.11"
@@ -38,7 +38,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.x-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }

--- a/src/SimpleThings/EntityAudit/AuditConfiguration.php
+++ b/src/SimpleThings/EntityAudit/AuditConfiguration.php
@@ -158,16 +158,8 @@ class AuditConfiguration
         return $callable ? $callable() : null;
     }
 
-    public function setUsernameCallable($usernameCallable)
+    public function setUsernameCallable(callable $usernameCallable = null)
     {
-        // php 5.3 compat
-        if (null !== $usernameCallable && !is_callable($usernameCallable)) {
-            throw new \InvalidArgumentException(sprintf(
-                'Username Callable must be callable. Got: %s',
-                is_object($usernameCallable) ? get_class($usernameCallable) : gettype($usernameCallable)
-            ));
-        }
-
         $this->usernameCallable = $usernameCallable;
     }
 


### PR DESCRIPTION
replace #212

We shouldn't change the array syntax etc. everywhere so that we don't have too much conflicts.

thanks @bendavies

closed #207