### PR TITLE
Rename all global_ignore_columns to global_ignore_properties

### DIFF
--- a/src/SimpleThings/EntityAudit/DependencyInjection/Configuration.php
+++ b/src/SimpleThings/EntityAudit/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('audited_entities')
                     ->prototype('scalar')->end()
                 ->end()
-                ->arrayNode('global_ignore_columns')
+                ->arrayNode('global_ignore_properties')
                     ->prototype('scalar')->end()
                 ->end()
                 ->scalarNode('table_prefix')->defaultValue('')->end()

--- a/src/SimpleThings/EntityAudit/DependencyInjection/SimpleThingsEntityAuditExtension.php
+++ b/src/SimpleThings/EntityAudit/DependencyInjection/SimpleThingsEntityAuditExtension.php
@@ -45,7 +45,7 @@ class SimpleThingsEntityAuditExtension extends Extension
             'revision_type_field_name',
             'revision_table_name',
             'revision_id_field_type',
-            'global_ignore_columns',
+            'global_ignore_properties',
         );
 
         foreach ($configurables as $key) {

--- a/src/SimpleThings/EntityAudit/Resources/config/auditable.xml
+++ b/src/SimpleThings/EntityAudit/Resources/config/auditable.xml
@@ -6,7 +6,7 @@
 
     <parameters>
         <parameter key="simplethings.entityaudit.audited_entities" type="collection" />
-        <parameter key="simplethings.entityaudit.global_ignore_columns" type="collection" />
+        <parameter key="simplethings.entityaudit.global_ignore_properties" type="collection" />
         <parameter key="simplethings.entityaudit.table_prefix" type="string" />
         <parameter key="simplethings.entityaudit.table_suffix" type="string" />
         <parameter key="simplethings.entityaudit.revision_field_name" type="string" />

--- a/tests/SimpleThings/Tests/EntityAudit/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
+++ b/tests/SimpleThings/Tests/EntityAudit/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
@@ -73,7 +73,7 @@ class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCase
         $this->load(array());
 
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.audited_entities', array());
-        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.global_ignore_columns', array());
+        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.global_ignore_properties', array());
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.table_prefix', '');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.table_suffix', '_audit');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_table_name', 'revisions');
@@ -86,7 +86,7 @@ class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCase
     {
         $this->load(array(
             'audited_entities' => array('Entity1', 'Entity2'),
-            'global_ignore_columns' => array('created_at', 'updated_at'),
+            'global_ignore_properties' => array('created_at', 'updated_at'),
             'table_prefix' => 'prefix',
             'table_suffix' => 'suffix',
             'revision_table_name' => 'log',
@@ -96,7 +96,7 @@ class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCase
         ));
 
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.audited_entities', array('Entity1', 'Entity2'));
-        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.global_ignore_columns', array('created_at', 'updated_at'));
+        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.global_ignore_properties', array('created_at', 'updated_at'));
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.table_prefix', 'prefix');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.table_suffix', 'suffix');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_table_name', 'log');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Has tests?    | no

This PR fix error
```
[RuntimeException]                                                                                                                                                                                                       
  An error occurred when executing the "'cache:clear --no-warmup'" command:                                                                                                                                                
                                                                                                                                         
    [Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException]                                                                                                                                           
                                                                                                                                                                                                                           
    The service "simplethings_entityaudit.config" has a dependency on a non-existent parameter "simplethings.entityaudit.global_ignore_properties". Did you mean one of these: "simplethings.entityaudit.global_ignore_co  
  lumns", "simplethings.entityaudit.table_prefix"?    
```

Because not all global_ignore_columns was renamed after #244 