### PR TITLE
Check getGlobalIgnoreProperties before add an entity to the extraUpda…

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -294,6 +294,19 @@ class LogRevisionsListener implements EventSubscriber
                 continue;
             }
 
+            // get changes => should be already computed here (is a listener)
+            $changeset = $this->uow->getEntityChangeSet($entity);
+            foreach ($this->config->getGlobalIgnoreProperties() as $property) {
+                if (isset($changeset[$property])) {
+                    unset($changeset[$property]);
+                }
+            }
+
+            // if we have no changes left => don't create revision log
+            if (count($changeset) == 0) {
+                continue;
+            }
+
             $this->extraUpdates[spl_object_hash($entity)] = $entity;
         }
     }


### PR DESCRIPTION
…tes array

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Has tests?    | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

GlobalIngoreProperties should be checked before added an entity to `extraUpdates` during the onFlush event to prevent create unnecessary revisions.