### PR TITLE
Fix OneToOne reverse relation Doctrine fallback query

### DIFF
--- a/src/SimpleThings/EntityAudit/AuditReader.php
+++ b/src/SimpleThings/EntityAudit/AuditReader.php
@@ -420,18 +420,21 @@ class AuditReader
                 //print_r($targetClass->discriminatorMap);
                 if ($this->metadataFactory->isAudited($assoc['targetEntity'])) {
                     if ($this->loadAuditedEntities) {
+                        // Primary Key. Used for audit tables queries.
                         $pk = array();
+                        // Primary Field. Used when fallback to Doctrine finder.
+                        $pf = array();
 
                         if ($assoc['isOwningSide']) {
                             foreach ($assoc['targetToSourceKeyColumns'] as $foreign => $local) {
-                                $pk[$foreign] = $data[$columnMap[$local]];
+                                $pk[$foreign] = $pf[$foreign] = $data[$columnMap[$local]];
                             }
                         } else {
                             /** @var ClassMetadataInfo|ClassMetadata $otherEntityMeta */
-                            $otherEntityMeta = $this->em->getClassMetadata($assoc['targetEntity']);
+                            $otherEntityAssoc = $this->em->getClassMetadata($assoc['targetEntity'])->associationMappings[$assoc['mappedBy']];
 
-                            foreach ($otherEntityMeta->associationMappings[$assoc['mappedBy']]['targetToSourceKeyColumns'] as $local => $foreign) {
-                                $pk[$foreign] = $data[$class->getFieldName($local)];
+                            foreach ($otherEntityAssoc['targetToSourceKeyColumns'] as $local => $foreign) {
+                                $pk[$foreign] = $pf[$otherEntityAssoc['fieldName']] = $data[$class->getFieldName($local)];
                             }
                         }
 
@@ -448,7 +451,7 @@ class AuditReader
                                 $value = null;
                             } catch (NoRevisionFoundException $e) {
                                 // The entity does not have any revision yet. So let's get the actual state of it.
-                                $value = $this->em->find($targetClass->name, $pk);
+                                $value = $this->em->getRepository($targetClass->name)->findOneBy($pf);
                             }
 
                             $class->reflFields[$field]->setValue($entity, $value);

--- a/tests/SimpleThings/Tests/EntityAudit/CoreTest.php
+++ b/tests/SimpleThings/Tests/EntityAudit/CoreTest.php
@@ -35,6 +35,7 @@ class CoreTest extends BaseTest
     protected $schemaEntities = array(
         'SimpleThings\EntityAudit\Tests\Fixtures\Core\ArticleAudit',
         'SimpleThings\EntityAudit\Tests\Fixtures\Core\UserAudit',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Core\ProfileAudit',
         'SimpleThings\EntityAudit\Tests\Fixtures\Core\AnimalAudit',
         'SimpleThings\EntityAudit\Tests\Fixtures\Core\Fox',
         'SimpleThings\EntityAudit\Tests\Fixtures\Core\Rabbit',
@@ -46,6 +47,7 @@ class CoreTest extends BaseTest
     protected $auditedEntities = array(
         'SimpleThings\EntityAudit\Tests\Fixtures\Core\ArticleAudit',
         'SimpleThings\EntityAudit\Tests\Fixtures\Core\UserAudit',
+        'SimpleThings\EntityAudit\Tests\Fixtures\Core\ProfileAudit',
         'SimpleThings\EntityAudit\Tests\Fixtures\Core\AnimalAudit',
         'SimpleThings\EntityAudit\Tests\Fixtures\Core\Rabbit',
         'SimpleThings\EntityAudit\Tests\Fixtures\Core\Fox',
@@ -245,6 +247,27 @@ class CoreTest extends BaseTest
         $reader = $this->auditManager->createAuditReader($this->em);
 
         $this->assertSame('beberlei', $reader->find(get_class($article), 1, 1)->getAuthor()->getName());
+    }
+
+    public function testNotVersionedReverseRelationFind()
+    {
+        $user = new UserAudit('beberlei');
+
+        $this->em->persist($user);
+        $this->em->flush();
+
+        // Insert user without the manager to skip revision registering.
+        $this->em->getConnection()->insert(
+            $this->em->getClassMetadata('SimpleThings\EntityAudit\Tests\Fixtures\Core\ProfileAudit')->getTableName(),
+            array(
+                'biography' => 'He is an amazing contributor!',
+                'user_id' => 1,
+            )
+        );
+
+        $reader = $this->auditManager->createAuditReader($this->em);
+
+        $this->assertSame('He is an amazing contributor!', $reader->find(get_class($user), 1, 1)->getProfile()->getBiography());
     }
 
     public function testFindRevisions()

--- a/tests/SimpleThings/Tests/EntityAudit/Fixtures/Core/ProfileAudit.php
+++ b/tests/SimpleThings/Tests/EntityAudit/Fixtures/Core/ProfileAudit.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SimpleThings\EntityAudit\Tests\Fixtures\Core;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class ProfileAudit
+{
+    /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue */
+    private $id;
+
+    /** @ORM\Column(type="text") */
+    private $biography;
+
+    /** @ORM\OneToOne(targetEntity="UserAudit", inversedBy="profile") @ORM\JoinColumn(referencedColumnName="id", nullable=true) */
+    private $user;
+
+    public function __construct($biography)
+    {
+        $this->biography = $biography;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getBiography()
+    {
+        return $this->biography;
+    }
+
+    public function setBiography($biography)
+    {
+        $this->biography = $biography;
+    }
+
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    public function setUser($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/tests/SimpleThings/Tests/EntityAudit/Fixtures/Core/UserAudit.php
+++ b/tests/SimpleThings/Tests/EntityAudit/Fixtures/Core/UserAudit.php
@@ -14,6 +14,9 @@ class UserAudit
     /** @ORM\Column(type="string") */
     private $name;
 
+    /** @ORM\OneToOne(targetEntity="ProfileAudit", mappedBy="user") */
+    private $profile;
+
     function __construct($name)
     {
         $this->name = $name;
@@ -32,5 +35,19 @@ class UserAudit
     public function getName()
     {
         return $this->name;
+    }
+
+    public function getProfile()
+    {
+        return $this->profile;
+    }
+
+    /**
+     * @param ProfileAudit $profile
+     */
+    public function setProfile($profile)
+    {
+        $this->profile = $profile;
+        $profile->setUser($this);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Has tests?    | yes

The foreign column name was used on a classic Doctrine find.

Two issues:

* This method expects an identifier. So we have to get the repository to use findOneBy method instead.
* The findOneBy method expects fieldName, not column name. So primary field array is introduced.

I target the 1.0 branch because it's a bugfix of introduced feature in #227.

You can push the new patch release after this PR. :+1: 